### PR TITLE
fix(XMLPatch): support multiple sibling elements in replace operations

### DIFF
--- a/XMLPatch/Program.cs
+++ b/XMLPatch/Program.cs
@@ -592,16 +592,21 @@ namespace X4XmlDiffAndPatch
       {
         if (targetObj is XElement target)
         {
-          string targetName = target.Name.LocalName;
-          XElement? replaceSubElement = replaceElement.Element(targetName);
+          var replaceChildren = replaceElement.Elements().ToList();
           XElement? parent = target.Parent;
           string targetInfo = GetElementInfo(target);
           string parentInfo = GetElementInfo(parent);
-          if (replaceSubElement != null)
+          if (replaceChildren.Count > 0)
           {
-            string replaceInfo = GetElementInfo(replaceSubElement);
-            target.ReplaceWith(replaceSubElement);
-            Logger.Info($"Replaced element '{targetInfo}' with '{replaceInfo}' in '{parentInfo}'.");
+            // Insert all child elements from the replace operation
+            XNode lastInserted = target;
+            for (int i = replaceChildren.Count - 1; i >= 0; i--)
+            {
+              target.AddAfterSelf(replaceChildren[i]);
+            }
+            target.Remove();
+            string replaceInfo = GetElementInfo(replaceChildren[0]);
+            Logger.Info($"Replaced element '{targetInfo}' with '{replaceInfo}'{(replaceChildren.Count > 1 ? $" and {replaceChildren.Count - 1} sibling(s)" : "")} in '{parentInfo}'.");
           }
           else
           {


### PR DESCRIPTION
## Summary

- `ApplyReplace` used `replaceElement.Element(targetName)` which only returns the **first** matching child element, silently dropping any additional siblings
- Fixed to insert **all** child elements from the `<replace>` operation, preserving their order
- Added logging to indicate when multiple siblings are inserted (e.g. `"and 3 sibling(s)"`)

## Problem

When a `<replace>` diff operation contains multiple sibling elements:

```xml
<replace sel="path/to/do_if[@value='...']">
  <do_if value="...">...</do_if>
  <do_elseif value="...">...</do_elseif>
  <do_elseif value="...">...</do_elseif>
</replace>
```

Only the first `<do_if>` was inserted — the `<do_elseif>` elements were silently dropped. This is a valid pattern in X4 diff patches where a single element is replaced with an if/elseif chain.

## Fix

Instead of `replaceElement.Element(targetName)` (single element), the fix uses `replaceElement.Elements().ToList()` to collect all children, then inserts them in order using `AddAfterSelf` before removing the original target.

## Test plan

- [x] Verified with X4 diff patches containing multi-sibling `<replace>` operations
- [x] Single-element replacements continue to work as before
- [x] Attribute and text node replacements are unaffected